### PR TITLE
Add support for JLS 21 as the parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # java-callgraph
 
 ## Prerequisites
-1. Java 17
+1. Java 21
 ```sh
-sudo apt install openjdk-17-jdk
+sudo apt install openjdk-21-jdk
 ```
 2. [maven 3.9.11](https://maven.apache.org/install.html)
-3. [Eclipse IDE for Eclipse Committers (2023-12)](https://www.eclipse.org/downloads/packages/release/2023-12/r/eclipse-ide-eclipse-committers)
+3. [Eclipse IDE for Eclipse Committers (2025-09)](https://www.eclipse.org/downloads/packages/release/2025-09/r/eclipse-ide-eclipse-committers)
 
 ## Clone the repository:
 ```

--- a/bundles/org.openrefactory.callgraph/META-INF/MANIFEST.MF
+++ b/bundles/org.openrefactory.callgraph/META-INF/MANIFEST.MF
@@ -4,14 +4,14 @@ Bundle-Name: CallGraph
 Bundle-SymbolicName: org.openrefactory.callgraph;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: OpenRefactory
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Import-Package: org.json;version="20250517.0.0"
 Require-Bundle: 
- org.eclipse.jface.text;bundle-version="3.22.0",
- org.eclipse.jdt.core;bundle-version="3.32.0",
- org.eclipse.jdt.ui;bundle-version="3.27.100",
- org.eclipse.jface;bundle-version="3.28.0",
- org.eclipse.core.runtime;bundle-version="3.26.100",
- org.eclipse.core.resources;bundle-version="3.18.100",
+ org.eclipse.jface.text;bundle-version="3.28.100",
+ org.eclipse.jdt.core;bundle-version="3.43.0",
+ org.eclipse.jdt.ui;bundle-version="3.35.100",
+ org.eclipse.jface;bundle-version="3.38.0",
+ org.eclipse.core.runtime;bundle-version="3.34.0",
+ org.eclipse.core.resources;bundle-version="3.23.0",
  org.junit;bundle-version="4.13.2";resolution:=optional
 Automatic-Module-Name: org.openrefactory.callgraph

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tycho-version>4.0.5</tycho-version>
+    <tycho-version>5.1.0</tycho-version>
   </properties>
 
   <modules>

--- a/target-platform.target
+++ b/target-platform.target
@@ -12,9 +12,9 @@
     <!-- P2 dependencies -->
     <!-- Maven dependencies -->
 	  <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-		  <repository location="https://download.eclipse.org/releases/2023-12/202312061001"/>
-		  <unit id="org.eclipse.jdt.feature.group" version="3.19.300.v20231201-0110"/>
-		  <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.2300.v20231106-1826"/>
+		  <repository location="https://download.eclipse.org/releases/2025-09/202509101001"/>
+		  <unit id="org.eclipse.jdt.feature.group" version="3.20.300.v20250905-1111"/>
+		  <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.3000.v20250801-0854"/>
 	  </location>
 	  <location includeDependencyDepth="none" includeDependencyScopes="compile" missingManifest="error" type="Maven">
 		  <dependencies>


### PR DESCRIPTION

## Changes Summary

### Files Modified
- `README.md`
- `bundles/org.openrefactory.callgraph/META-INF/MANIFEST.MF`
- `pom.xml`
- `target-platform.target`

---

## Detailed Changes

### 1. **README.md** - Java & Eclipse Version Updates

| Component | main(current) | new |
|-----------|------------|---------------|
| Java Version | 17 | 21 |
| Installation Command | `sudo apt install openjdk-17-jdk` | `sudo apt install openjdk-21-jdk` |
| Eclipse IDE | 2023-12 | 2025-09 |

---

### 2. **MANIFEST.MF** - Bundle Dependencies

#### Execution Environment
```diff
- Bundle-RequiredExecutionEnvironment: JavaSE-17
+ Bundle-RequiredExecutionEnvironment: JavaSE-21
```

#### Eclipse Bundle Versions

| Bundle | main (current) | new |
|--------|------------|---------------|
| `org.eclipse.jface.text` | 3.22.0 | 3.28.100 |
| `org.eclipse.jdt.core` | 3.32.0 | 3.43.0 |
| `org.eclipse.jdt.ui` | 3.27.100 | 3.35.100 |
| `org.eclipse.jface` | 3.28.0 | 3.38.0 |
| `org.eclipse.core.runtime` | 3.26.100 | 3.34.0 |
| `org.eclipse.core.resources` | 3.18.100 | 3.23.0 |

---

### 3. **pom.xml** - Maven Tycho Plugin

```diff
- <tycho-version>4.0.5</tycho-version>
+ <tycho-version>5.1.0</tycho-version>
```

---

### 4. **target-platform.target** - Eclipse Platform

#### Repository Location
```diff
- <repository location="https://download.eclipse.org/releases/2023-12/202312061001"/>
+ <repository location="https://download.eclipse.org/releases/2025-09/202509101001"/>
```

#### Eclipse Features

| Feature | main(current) | new |
|---------|------------|---------------|
| `org.eclipse.jdt.feature.group` | 3.19.300.v20231201-0110 | 3.20.300.v20250905-1111 |
| `org.eclipse.equinox.executable.feature.group` | 3.8.2300.v20231106-1826 | 3.8.3000.v20250801-0854 |

---

## Migration Impact
-  **Java 21** - Updated LTS version with modern language features
-  **Eclipse 2025-09** - Latest Eclipse platform release
-  **Tycho 5.1.0** - Updated Maven Tycho for Eclipse plugin builds
-  **All Eclipse bundles** updated to compatible versions

