### PR TITLE
feat: Add extended call graph call sites test suite (#29)

### DIFF
--- a/bundles/org.openrefactory.callgraph/src/org/openrefactory/test/ExtendedCallGraphCallSitesTestSuite.java
+++ b/bundles/org.openrefactory.callgraph/src/org/openrefactory/test/ExtendedCallGraphCallSitesTestSuite.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (C) 2025-present OpenRefactory, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.openrefactory.test;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.openrefactory.analysis.callgraph.CallGraphDataStructures;
+import org.openrefactory.analysis.callgraph.ExtendedCallGraph;
+import org.openrefactory.analysis.callgraph.MultiThreadCallGraphProcessor;
+import org.openrefactory.analysis.vpg.JavaVPG;
+import org.openrefactory.model.Model;
+import org.openrefactory.model.eclipse.EclipseModel;
+import org.openrefactory.util.CallGraphUtility;
+import org.openrefactory.util.datastructure.IntPair;
+import org.openrefactory.util.datastructure.TokenRange;
+import org.openrefactory.util.manager.C2PManager;
+import org.openrefactory.util.manager.C2SManager;
+import org.openrefactory.util.manager.FNDSpecManager;
+import org.openrefactory.util.manager.SpecialRootSpecManager;
+import org.openrefactory.util.progressreporter.IProgressReporter;
+import org.openrefactory.util.progressreporter.NullProgressReporter;
+import org.openrefactory.util.test.GeneralTestSuiteFromMarkers;
+import org.openrefactory.util.test.JUnitCommandLineTestCase;
+import org.openrefactory.util.test.JavaTestUtility;
+import org.openrefactory.util.test.MarkerUtil;
+import org.openrefactory.util.test.TestUtility;
+
+import junit.framework.Test;
+
+/**
+ * Issue 29
+ * A test suite for testing whether call site token ranges are kept correctly in the call graphs.
+ *
+ * @author Munawar Hafiz
+ */
+public class ExtendedCallGraphCallSitesTestSuite extends GeneralTestSuiteFromMarkers {
+
+    private static final File DIRECTORY = new File("callgraph-tests" + File.separator);
+
+    private String COMMA_PLACEHOLDER = "@@@";
+
+    public static Test suite() throws Exception {
+        return new ExtendedCallGraphCallSitesTestSuite();
+    }
+
+    public ExtendedCallGraphCallSitesTestSuite() throws Exception {
+        super("Running extended call graph call sites tests", "/*!!!!!", JavaTestUtility.MARKER_END, DIRECTORY,
+                JavaTestUtility.JAVA_FILENAME_FILTER);
+    }
+
+    @Override
+    protected Test createTestFor(File fileContainingMarker, int markerOffset, String markerText) throws Exception {
+        return new ExtendedCallGraphCallSitesTestCase(fileContainingMarker, markerOffset, markerText);
+    }
+
+    public class ExtendedCallGraphCallSitesTestCase extends JUnitCommandLineTestCase {
+        private File file;
+
+        private String markerText;
+
+        public ExtendedCallGraphCallSitesTestCase(File file, int markerOffset, String markerText) {
+            super("test");
+            this.file = file;
+            this.markerText = markerText;
+        }
+
+        /*
+         * Marker = caller, number of callsites, [set of Pair of offset and lengths]
+         * The caller is a comma separated method signature strings.
+         */
+        public void test() throws Exception {
+            JavaVPG javaVPG = JavaVPG.getInstance();
+            // Initialize work space and clear all ASTs
+            IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
+            Model.getInstance().deinitialize();
+            root.delete(true, true, null);
+            JavaVPG.getInstance().releaseAllASTs();
+            // Copy all the files in the project directory into a temp directory
+            // and conduct the calculations there
+            String rootPath = root.getRawLocation().toOSString();
+            File rootFile = new File(rootPath);
+            String projectPath = rootFile.getAbsolutePath() + File.separator + "TestProject";
+            File absoluteFile = file.getAbsoluteFile();
+            File temp = file.getAbsoluteFile();
+
+            temp = TestUtility.getTestContainerDirectory(temp);
+            File copiedFileContainingMarker = TestUtility.copyFolder(temp,
+                    new File(projectPath + File.separator + absoluteFile.getName()), absoluteFile);
+            // Create Eclipse File System Model
+            try {
+                Model.useModel(new EclipseModel(
+                        new File(projectPath + File.separator + copiedFileContainingMarker.getName())));
+            } catch (CoreException e) {
+                e.printStackTrace();
+            }
+            javaVPG.releaseAllASTs();
+
+            LinkedList<String> markers = MarkerUtil.parseMarker(markerText);
+            String expectedCaller = markers.removeFirst();
+            expectedCaller = expectedCaller.replaceAll(COMMA_PLACEHOLDER, ",");
+            int calleeCount = Integer.parseInt(markers.removeFirst());
+            Set<TokenRange> expectedCallSites = new HashSet<>(calleeCount);
+            for (int i = 0; i < calleeCount; i++) {
+                int offset = Integer.parseInt(markers.removeFirst());
+                int length = Integer.parseInt(markers.removeFirst());
+                TokenRange expectedCallSite = new TokenRange(offset, length);
+                expectedCallSites.add(expectedCallSite);
+            }
+            IProgressReporter progressReporter = new NullProgressReporter();
+            CallGraphDataStructures.initialize();
+            C2PManager.loadC2PInfo(progressReporter);
+            C2SManager.loadC2SInfo(progressReporter);
+            FNDSpecManager.loadFNDSpecInfo(progressReporter);
+            SpecialRootSpecManager.loadSpecsFromJson(progressReporter);
+
+            MultiThreadCallGraphProcessor.BuildAndProcessCallGraph(true, progressReporter, projectPath);
+            ExtendedCallGraph callGraph = CallGraphDataStructures.getExtendedCallGraph();
+            // Null check
+            assertNotNull("In " + file + ", Expected a call graph, but found null", callGraph);
+            // Match the caller
+            String matchedCallerHash = null;
+            for (Entry<String, Map<TokenRange, Set<String>>> callerToCalleeEntries : callGraph
+                    .getCallerToCalleeMap().entrySet()) {
+                String callerHash = callerToCalleeEntries.getKey();
+                String callerName = CallGraphUtility.getMethodNameInCanonicalizedFormat(callerHash, true);
+                if (callerName.equals(expectedCaller)) {
+                    matchedCallerHash = callerHash;
+                    break;
+                }
+            }
+            if (calleeCount == 0) {
+                assertNull("In " + file + ", The following caller should not be present: " + expectedCaller
+                        + ", but it was.", matchedCallerHash);
+                return;
+            } else {
+                assertNotNull(
+                        "In " + file + ", Expected the following caller " + expectedCaller + ", but did not find it.",
+                        matchedCallerHash);
+            }
+            // Get the callsite and callees from the only caller in the map
+            Map<TokenRange, Set<String>> foundCallsitesAndCallees = callGraph.getCallerToCalleeMap()
+                    .get(matchedCallerHash);
+            // First collect the callees
+            Set<IntPair> foundCallsites = new HashSet<>(2);
+            for (Entry<TokenRange, Set<String>> entry : foundCallsitesAndCallees.entrySet()) {
+                TokenRange calculatedTokenRange = entry.getKey();
+                assertNotNull(
+                        "In " + file + ", The token range for a callsite from " + expectedCaller + " is null",
+                        calculatedTokenRange);
+                foundCallsites.add(IntPair.of(calculatedTokenRange.getOffset(), calculatedTokenRange.getLength()));
+            }
+            // Match the number of callees for the caller
+            assertTrue(
+                    "In " + file + ", For the following caller " + expectedCaller + ", expected "
+                            + expectedCallSites.size() + " callees, but found " + foundCallsites.size(),
+                    foundCallsites.size() == expectedCallSites.size());
+            // Match each callsite
+            for (TokenRange expectedCallSite : expectedCallSites) {
+                assertTrue(
+                        "In " + file + ", For the following caller " + expectedCaller
+                                + ", expected the following callsites: " + expectedCallSite + ", but found the following "
+                                + foundCallsites,
+                        foundCallsites
+                                .contains(IntPair.of(expectedCallSite.getOffset(), expectedCallSite.getLength())));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Introduced `ExtendedCallGraphCallSitesTestSuite` to validate that call site token ranges are correctly preserved in extended call graphs.

Key changes:
- Added `ExtendedCallGraphCallSitesTestSuite` test framework
- Tests call site token ranges (offset and length) for each caller-callee relationship
- Supports marker-based test specification for call sites
- Validates correct positioning of method invocations in source code