### PR TITLE
feat: Add call-site token-range markers and position support (#30)

### DIFF
--- a/bundles/org.openrefactory.callgraph/callgraph-tests/002-multiple-class-method/MultiClassSameMethodName.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/002-multiple-class-method/MultiClassSameMethodName.java
@@ -40,6 +40,10 @@ public class MultiClassSameMethodName {
     }
 }
 
+/*<<<<<8,4,10,4,caller,MultiClassSameMethodName:main([QString;)V,D:foo(QA;)QA;*/
+
+/*<<<<<35,16,35,29,caller, MultiClassSameMethodName:main([QString;)V,D:foo(QA;)QA;*/
+
 // Explanation:
 // (1) marker 1 selected class B's foo() method and its caller is according
 //     to the algorithm class D's foo() and class MultiClassSameMethodName's main().

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/071-static-method-call-in-xcg-Bug3/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/071-static-method-call-in-xcg-Bug3/Test.java
@@ -24,6 +24,9 @@ class A {
 }
 
 /*$$$$$ Test.main(String[]), 2, Test.foo(), Test.bar() */
+
+/*!!!!! Test.main(String[]), 2, 145,5, 160, 10 */
+
 /*$$$$$ Test.foo(), 2, A.b(), Test.bar() */
 /*$$$$$ Test.bar(), 0 */
 

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/072-library-sub-override-xcg-Bug3/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/072-library-sub-override-xcg-Bug3/Test.java
@@ -20,3 +20,5 @@ class A extends Dummy {
 }
 
 /*$$$$$ Test.main(String[]), 3, org.dummy.Dummy#b(), A#b(), Test.<init>() */
+
+/*!!!!! Test.main(String[]), 2, 267,10, 298,5 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/073-inner-class-method-Bug3/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/073-inner-class-method-Bug3/Test.java
@@ -36,9 +36,15 @@ public class Outer {
 
 /*$$$$$ org.test.Outer.Inner#display(), 1, org.test.Outer#printMessage() */
 
+/*!!!!! org.test.Outer.Inner#display(), 1, 405, 14 */
+
 /*$$$$$ org.test.Outer#printMessage(), 0 */
+
+/*!!!!! org.test.Outer#printMessage(), 0 */
 
 /*$$$$$ org.test.Outer.main(String[]), 3, 
      org.test.Outer.<init>(), 
      org.test.Outer.Inner.<init>(), 
      org.test.Outer.Inner#display() */
+
+/*!!!!! org.test.Outer.main(String[]), 3, 711,11, 822, 17, 900, 15 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/074-anon-class-default-Bug3/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/074-anon-class-default-Bug3/Test.java
@@ -57,10 +57,14 @@ class AnonymousDemo {
    AnonymousDemo#foo2()$Polygon$2#getVal(), 
  */
 
+/*!!!!! AnonymousDemo#foo1(),  2, 424, 105, 542,11 */
+
 /*$$$$$ AnonymousDemo#foo1()$Polygon$1.<init>(), 
   1, 
   Polygon#Polygon(String@@@String) 
 */
+
+/*!!!!! AnonymousDemo#foo1()$Polygon$1.<init>(), 1, 448, 81 */
 
 
 /*$$$$$ AnonymousDemo#foo2(), 
@@ -73,12 +77,18 @@ class AnonymousDemo {
    AnonymousDemo#foo2()$Polygon$1#getVal(), 
  */
 
+/*!!!!! AnonymousDemo#foo2(), 3, 600, 99, 713,99,  826, 11 */
+
 /*$$$$$ AnonymousDemo#foo2()$Polygon$1.<init>(), 
   1,
   Polygon#Polygon() 
 */
 
+/*!!!!! AnonymousDemo#foo2()$Polygon$1.<init>(), 1, 614, 85 */
+
 /*$$$$$ AnonymousDemo#foo2()$Polygon$2.<init>(), 
   1,
   Polygon#Polygon() 
 */
+
+/*!!!!! AnonymousDemo#foo2()$Polygon$2.<init>(), 1, 727, 85*/

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/075-anon-inner-class-Bug3/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/075-anon-inner-class-Bug3/Test.java
@@ -41,12 +41,18 @@ class AnonymousDemo {
    org.openrefactory.test.Polygon#getVal() 
  */
 
+/*!!!!! org.openrefactory.test.AnonymousDemo#foo2(), 3, 366, 99, 479, 99, 592,11 */
+
 /*$$$$$ org.openrefactory.test.AnonymousDemo#foo2()$Polygon$1.<init>(), 
   1,
   org.openrefactory.test.Polygon.<init>() 
 */
 
+/*!!!!! org.openrefactory.test.AnonymousDemo#foo2()$Polygon$1.<init>(), 1, 380,85 */
+
 /*$$$$$ org.openrefactory.test.AnonymousDemo#foo2()$Polygon$2.<init>(), 
   1,
   org.openrefactory.test.Polygon.<init>() 
 */
+
+/*!!!!! org.openrefactory.test.AnonymousDemo#foo2()$Polygon$2.<init>(), 1, 493, 85 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/076-member-inner-class-Bug3/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/076-member-inner-class-Bug3/Test.java
@@ -27,14 +27,22 @@ class Outer {
    org.openrefactory.test.Outer.Inner#show(),
  */
 
+/*!!!!! org.openrefactory.test.Outer.main(String[]), 3, 339,11, 380,17, 407,12 */
+
 /*$$$$$ org.openrefactory.test.Outer.Inner.<init>(), 
   0, 
 */
+
+/*!!!!! org.openrefactory.test.Outer.Inner.<init>(), 0 */
 
 /*$$$$$ org.openrefactory.test.Outer.<init>(), 
   0, 
 */
 
+/*!!!!! org.openrefactory.test.Outer.<init>(), 0 */
+
 /*$$$$$ org.openrefactory.test.Outer.Inner#show(),
   0,
 */
+
+/*!!!!! org.openrefactory.test.Outer.Inner#show(), 0, */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/077-static-inner-class-Bug3/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/077-static-inner-class-Bug3/Test.java
@@ -37,3 +37,8 @@ class Outer {
   1,
   org.openrefactory.test.Outer.<staticinit>()
 */
+
+/*!!!!! org.openrefactory.test.Outer.main(String[]), 2, 348,18, 376,13 */
+/*!!!!! org.openrefactory.test.Outer.Nested.<init>(), 0 */
+/*!!!!! org.openrefactory.test.Outer.<init>(), 0 */
+/*!!!!! org.openrefactory.test.Outer.Nested#show(), 1, 201, 64 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/078-local-inner-class-Bug3/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/078-local-inner-class-Bug3/Test.java
@@ -37,3 +37,7 @@ class Outer {
 /*$$$$$ org.openrefactory.test.Outer.<init>(), 
   0, 
 */
+
+/*!!!!! org.openrefactory.test.Outer.main(String[]), 2, 431,11, 431,21 */
+/*!!!!! org.openrefactory.test.Outer#display(), 2, 331,16, 357,12 */
+/*!!!!! org.openrefactory.test.Outer.<init>(), 0 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/079-anon-inner-class-Bug3/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/079-anon-inner-class-Bug3/Test.java
@@ -23,3 +23,5 @@ class Outer {
    org.openrefactory.test.Outer.main(String[])$Greeting$1.<init>(),
    org.openrefactory.test.Outer.main(String[])$Greeting$1#sayHello(),
  */
+
+/*!!!!! org.openrefactory.test.Outer.main(String[]), 2, 239,168, 417,12 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/080-deeply-nested-Bug3/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/080-deeply-nested-Bug3/Test.java
@@ -31,3 +31,5 @@ class Outer {
    org.openrefactory.test.Outer.Inner1.Inner2.Inner3.<init>(),
    org.openrefactory.test.Outer.Inner1.Inner2.Inner3#show(),
  */
+
+/*!!!!! org.openrefactory.test.Outer.main(String[]), 5, 400,11, 443,18, 500,19, 565,19, 594,13 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/081-nested-inside-static-Bug3/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/081-nested-inside-static-Bug3/Test.java
@@ -26,3 +26,5 @@ class Outer {
    org.openrefactory.test.Outer.Nested.InnerInNested.<init>(),
    org.openrefactory.test.Outer.Nested.InnerInNested#show(),
  */
+
+/*!!!!! org.openrefactory.test.Outer.main(String[]), 3, 386,18, 449,26, 485,12 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/082-super-method-Bug3/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/082-super-method-Bug3/Test.java
@@ -36,3 +36,7 @@ class Child extends Parent {
 /*$$$$$ org.openrefactory.test.Parent#greet(), 
    0
 */
+
+/*!!!!! org.openrefactory.test.Child.main(String[]), 2, 399,11, 399,19 */
+/*!!!!! org.openrefactory.test.Child#greet(), 1, 252,13 */
+/*!!!!! org.openrefactory.test.Parent#greet(), 0 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/083-super-constructor-Bug3/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/083-super-constructor-Bug3/Test.java
@@ -32,3 +32,6 @@ class Child extends Parent {
    org.openrefactory.test.Parent#Parent(String),
    org.openrefactory.test.Child.<init>(),
 */
+
+/*!!!!! org.openrefactory.test.Child.main(String[]), 1, 415,11 */
+/*!!!!! org.openrefactory.test.Child#Child(), 2, 261,27, 243,117 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/084-super-constructor-no-param-Bug3/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/084-super-constructor-no-param-Bug3/Test.java
@@ -32,3 +32,6 @@ class Child extends Parent {
    org.openrefactory.test.Parent#Parent(),
    org.openrefactory.test.Child.<init>(),
 */
+
+/*!!!!! org.openrefactory.test.Child.main(String[]), 1, 350,11 */
+/*!!!!! org.openrefactory.test.Child#Child(), 2, 232,8, 214,81 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/085-super-cons-default-cons-Bug3/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/085-super-cons-default-cons-Bug3/Test.java
@@ -30,3 +30,5 @@ class Child extends Parent {
    org.openrefactory.test.Parent.<init>(),
    org.openrefactory.test.Child.<init>(),
 */
+
+/*!!!!! org.openrefactory.test.Child#Child(), 2, 182,81, 200,8 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/086-super-method-ladder-Bug3/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/086-super-method-ladder-Bug3/Test.java
@@ -33,3 +33,6 @@ class Child extends Parent {
    1,
    org.openrefactory.test.Parent#work(),
 */
+
+/*!!!!! org.openrefactory.test.Child.main(String[]), 2, 412,11, 412,18 */
+/*!!!!! org.openrefactory.test.Child#work(), 1, 258,12 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/087-overloaded-super-method-Bug3/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/087-overloaded-super-method-Bug3/Test.java
@@ -34,3 +34,5 @@ class Child extends Parent {
    1,
    org.openrefactory.test.Parent#show(String),
 */
+
+/*!!!!! org.openrefactory.test.Child#show(), 1, 345,30 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/089-super-in-inheritance-Bug3/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/089-super-in-inheritance-Bug3/Test.java
@@ -38,3 +38,6 @@ class SubOuter extends Outer {
    1,
    org.openrefactory.test.Outer#display(),
 */
+
+/*!!!!! org.openrefactory.test.SubOuter.main(String[]), 3, 494,14, 494,26, 530,12 */
+/*!!!!! org.openrefactory.test.SubOuter.Inner#show(), 1, 350,24 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/090-super-inheritance-Bug3/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/090-super-inheritance-Bug3/Test.java
@@ -21,3 +21,5 @@ class Child extends Parent {
    org.openrefactory.test.Parent#Parent(int),
     org.openrefactory.test.Child.<init>(),
  */
+
+/*!!!!! org.openrefactory.test.Child#Child(), 2, 325,10, 307,126 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/091-super-method-call-Bug3/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/091-super-method-call-Bug3/Test.java
@@ -41,3 +41,6 @@ class SubOuter extends Outer {
    1,
    org.openrefactory.test.BaseInner#display(),
 */
+
+/*!!!!! org.openrefactory.test.SubOuter.main(String[]), 3, 593,14, 593,26, 629,12 */
+/*!!!!! org.openrefactory.test.SubOuter.Inner#show(), 1, 483,15 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/092-three-super-inheritance-examples-Bug3/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/092-three-super-inheritance-examples-Bug3/Test.java
@@ -52,3 +52,5 @@ class BaseInner {
    org.openrefactory.test.SubOuter.Inner#display(),
    org.openrefactory.test.Outer#display(),
 */
+
+/*!!!!! org.openrefactory.test.SubOuter.Inner#show(), 3, 548,14, 676,15, 813,24 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/093-this-constructor-Bug3/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/093-this-constructor-Bug3/Test.java
@@ -32,3 +32,5 @@ class Car {
    1,
    org.openrefactory.test.Car#Car(),
 */
+
+/*!!!!! org.openrefactory.test.Car#Car(String), 1, 272,7 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/094-cons-chaining-this-Bug3/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/094-cons-chaining-this-Bug3/Test.java
@@ -42,3 +42,7 @@ class Box {
     1,
     org.openrefactory.test.Box#Box(int@@@int@@@int),
 */
+
+/*!!!!! org.openrefactory.test.Box.main(String[]), 1, 554,9 */
+/*!!!!! org.openrefactory.test.Box#Box(), 1, 199,8 */
+/*!!!!! org.openrefactory.test.Box#Box(int), 1, 262,23 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/095-cons-chaining-this-Bug3/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/095-cons-chaining-this-Bug3/Test.java
@@ -44,3 +44,6 @@ class Person {
     1,
     org.openrefactory.test.Person#Person(String@@@int),
 */
+
+/*!!!!! org.openrefactory.test.Person#Person(String), 1, 215,14 */
+/*!!!!! org.openrefactory.test.Person#Person(int), 1, 307,21 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/096-default-cons-link-Bug3/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/096-default-cons-link-Bug3/Test.java
@@ -42,3 +42,6 @@ class B{
    1,
    org.openrefactory.test.Counter.<init>(),
 */
+
+/*!!!!! org.openrefactory.test.Counter.<init>(), 2, 156,7, 156,14 */
+/*!!!!! org.openrefactory.test.Counter#Counter(), 1, 191,36 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/097-constructor-chaining-Bug3/MultiClassWithOverloadedMethods.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/097-constructor-chaining-Bug3/MultiClassWithOverloadedMethods.java
@@ -59,3 +59,7 @@ public class MultiClassWithOverloadedMethods {
 
 /*$$$$$ D.<init>(), 1, A.<init>() */
 
+/*!!!!! A.<init>(), 0 */
+/*!!!!! B.<init>(), 1, 240,68 */
+/*!!!!! C.<init>(), 1, 483,111 */
+/*!!!!! D.<init>(), 1, 310,171 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/098-initializer-block-Bug3/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/098-initializer-block-Bug3/Test.java
@@ -38,3 +38,8 @@ class B{
   org.openrefactory.test.B.<init>(),
   org.openrefactory.test.B#getS(),
 */
+
+/*!!!!!
+org.openrefactory.test.Counter.<init>(), 2,
+404,7, 404, 14
+*/

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/099-static-initializer-Bug3/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/099-static-initializer-Bug3/Test.java
@@ -35,3 +35,8 @@ class B{
   org.openrefactory.test.B.<init>(),
   org.openrefactory.test.B#getS(),
 */
+
+/*!!!!!
+org.openrefactory.test.Counter.<staticinit>(), 2,
+280,7, 280,14
+*/

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/100-static-non-init-Bug3/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/100-static-non-init-Bug3/Test.java
@@ -86,3 +86,8 @@ org.openrefactory.test.B#getS(),
 org.openrefactory.test.Counter#Counter(), 1, 
 org.openrefactory.test.Counter.<init>(),
 */
+
+/*!!!!! org.openrefactory.test.Counter.<init>(), 2, 316,7, 316,14 */
+/*!!!!! org.openrefactory.test.Counter.main(String[]), 2, 443,13, 382, 202 */
+/*!!!!! org.openrefactory.test.Counter.<staticinit>(), 4, 211,7, 211,14, 271,7, 271,14 */
+/*!!!!! org.openrefactory.test.Counter#Counter(), 1, 343,33 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/101-static-nested-cons-Bug23/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/101-static-nested-cons-Bug23/Test.java
@@ -37,3 +37,6 @@ public class AnotherClass {
 AnotherClass.main(String[]), 1,
 Example6Custom.Pair#Pair(K@@@V)
 */
+
+/*!!!!! Example6Custom#demo(), 1, 339,33 */
+/*!!!!! AnotherClass.main(String[]), 1, 562,48 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/102-library-call-Bug25/Z.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/102-library-call-Bug25/Z.java
@@ -45,3 +45,5 @@ class MultithreadingDemo implements Callable<Integer>
   MultithreadingDemo#call(), 1,
   Z.<staticinit>()
 */
+
+/*!!!!! MultithreadingDemo#call(), 1, 531,110 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/103-library-constructor-Bug25/Z.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/103-library-constructor-Bug25/Z.java
@@ -15,3 +15,8 @@ public class Example1 {
   java.util.Date#Date(),
   java.util.Date.<init>()
 */
+
+/*!!!!!
+Example1#demo(), 1,
+121, 10
+*/

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/104-library-cons-generic-Bug25/Z.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/104-library-cons-generic-Bug25/Z.java
@@ -15,3 +15,5 @@ public class Example2 {
   java.util.ArrayList#ArrayList(),
   java.util.ArrayList.<init>()
 */
+
+/*!!!!! Example2#demo(), 1, 155, 17 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/105-library-cons-generic-Bug25/Z.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/105-library-cons-generic-Bug25/Z.java
@@ -14,3 +14,5 @@ public class Example3 {
   Example3#demo(), 1,
   java.util.HashMap#HashMap(int),
 */
+
+/*!!!!! Example3#demo(), 1, 159,18 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/114-thread-cons-Bug25/Z.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/114-thread-cons-Bug25/Z.java
@@ -17,3 +17,5 @@ public class Example10 {
   java.lang.Thread#Thread(Object),
   java.lang.Thread#start()
 */
+
+/*!!!!! Example10#demo(), 2, 106, 48, 164, 9 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/115-inner-class-cons-Bug25/Z.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/115-inner-class-cons-Bug25/Z.java
@@ -19,3 +19,6 @@ public class Example4 {
   Example4#demo(), 1,
   Example4#demo()$Timer$1.<init>()
 */
+
+/*!!!!!
+Example4#demo(), 1, 127, 181 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/119-reflection-Bug25/Z.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/119-reflection-Bug25/Z.java
@@ -16,3 +16,5 @@ public class Example9 {
   java.lang.Class#getConstructor(),
   java.lang.reflect.Constructor#newInstance()
 */
+
+/*!!!!! Example9#demo(), 2, 178, 27, 224, 15 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/120-clone-Bug25/Z.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/120-clone-Bug25/Z.java
@@ -16,3 +16,5 @@ public class Example10 {
   java.util.ArrayList.<init>(),
   java.util.ArrayList#clone()
 */
+
+/*!!!!! Example10#demo(), 2, 164,17, 237, 13*/

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/121-serialization-Bug25/Z.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/121-serialization-Bug25/Z.java
@@ -17,3 +17,5 @@ public class Example11 {
   java.io.FileInputStream#FileInputStream(String),
   java.io.ObjectInputStream#readObject()
 */
+
+/*!!!!! Example11#demo(), 3, 167, 30, 145, 53, 225, 15 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/123-super-method-Bug25/Z.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/123-super-method-Bug25/Z.java
@@ -24,3 +24,5 @@ public class MyList<E> extends ArrayList<E> {
   MyList#add(E), 1,
   java.util.ArrayList#add(E)
  */
+
+/*!!!!! MyList#add(E), 1, 246,12 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/132-default-cons-field-init-super-Bug25/Z.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/132-default-cons-field-init-super-Bug25/Z.java
@@ -36,3 +36,6 @@ public class Example1 {
   Example1.<init>(), 1,
   java.time.LocalDate.now(),
 */
+
+/*!!!!! Example1#show(), 0 */
+/*!!!!! Example1.<init>(), 1, 197,15 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/133-static-field-init-Bug25/Z.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/133-static-field-init-Bug25/Z.java
@@ -12,11 +12,14 @@ public class Example2 {
     }
 }
 
+/*!!!!! Example2.main(String[]), 1,  249, 95  */
+
 /*$$$$$
   Example2.main(String[]), 1,
   Example2.<staticinit>()
 */
 
+/*!!!!! Example2.<staticinit>(), 2, 214, 17, 214, 28 */
 
 /*$$$$$
   Example2.<staticinit>(), 2,

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/134-static-init-block-Bug25/Z.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/134-static-init-block-Bug25/Z.java
@@ -29,3 +29,6 @@ public class Example3 {
   java.time.LocalDateTime.now(),
   LocalDateTime#format(Object),
 */
+
+/*!!!!! Example3.main(String[]), 1, 360,103 */
+/*!!!!! Example3.<staticinit>(), 2, 265,19, 265,82 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/135-instance-init-Bug25/Z.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/135-instance-init-Bug25/Z.java
@@ -29,3 +29,6 @@ public class Example4 {
   java.util.Random#Random(),
   java.util.Random#nextInt(int),
 */
+
+/*!!!!! Example4.main(String[]), 1, 302, 14 */
+/*!!!!! Example4.<init>(), 2, 201, 12, 201, 26 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/136-chained-library-calls-Bug25/Z.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/136-chained-library-calls-Bug25/Z.java
@@ -25,3 +25,5 @@ public class Example6 {
   LocalDateTime#format(DateTimeFormatter),
   java.time.format.DateTimeFormatter.ofPattern(String)
 */
+
+/*!!!!! Example6.<init>(), 3, 193,19, 193, 111, 253, 50*/

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/138-instance-field-initialized-Bug25/Z.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/138-instance-field-initialized-Bug25/Z.java
@@ -21,3 +21,6 @@ public class Example8 {
   Example8.<init>(), 1,
   java.util.List.of(String@@@String@@@String),
 */
+
+/*!!!!! Example8.main(String[]), 1, 286,14 */
+/*!!!!! Example8.<init>(), 1, 151,31 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/139-variadic-Bug27/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/139-variadic-Bug27/Test.java
@@ -27,6 +27,6 @@ public class Example1 {
   1, Example1.printNumbers(int[]...)
 */
 
-/*!!!!! Example1.main(String[]), 3, 295, 15, 347, 27, 243,14 */
+/*!!!!! Example1.main(String[]), 3, 293, 15, 345, 27, 241,14 */
 
-/*!!!!! Example1.main2(String[]), 1, 462,14*/
+/*!!!!! Example1.main2(String[]), 1, 460,14*/

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/140-mix-variadic-Bug27/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/140-mix-variadic-Bug27/Test.java
@@ -26,6 +26,6 @@ public class Example2 {
   1, Example2.printSum(String@@@int[]...)
 */
 
-/*!!!!! Example2.main(String[]), 2,  299,26, 335,17, */
+/*!!!!! Example2.main(String[]), 2,  297,26, 333,17, */
 
-/*!!!!! Example2.main2(String[]), 1,  419,17, */
+/*!!!!! Example2.main2(String[]), 1,  417,17, */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/141-varargs-ref-Bug27/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/141-varargs-ref-Bug27/Test.java
@@ -25,6 +25,6 @@ public class Example3 {
   1, Example3.joinStrings(String[]...)
 */
 
-/*!!!!! Example3.main(String[]),  2, 263,43, 316,13 */
+/*!!!!! Example3.main(String[]),  2, 261,43, 314,13 */
 
-/*!!!!! Example3.main2(String[]),  1, 414,13 */
+/*!!!!! Example3.main2(String[]),  1, 412,13 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/142-varargs-array-Bug27/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/142-varargs-array-Bug27/Test.java
@@ -17,4 +17,4 @@ public class Example4 {
    1, Example4.printAll(String[]...)
  */
 
-/*!!!!! Example4.main(String[]), 1, 278,13 */
+/*!!!!! Example4.main(String[]), 1, 276,13 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/145-variadic-symbolic-Bug27/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/145-variadic-symbolic-Bug27/Test.java
@@ -22,4 +22,4 @@ public class Example6 {
    Example6.display(int)
  */
 
-/*!!!!! Example6.main(String[]), 2,  374,10, 432,16 */
+/*!!!!! Example6.main(String[]), 2,  372,10, 430,16 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/146-varargs-maybe-relax-Bug27/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/146-varargs-maybe-relax-Bug27/Test.java
@@ -17,4 +17,4 @@ public class Example7 {
    Example7.log(String@@@Object[]...)
  */
 
-/*!!!!! Example7.main(String[]), 1, 246, 56*/
+/*!!!!! Example7.main(String[]), 1, 244, 56*/

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/147-varargs-with-array-partial-match-Bug27/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/147-varargs-with-array-partial-match-Bug27/Test.java
@@ -18,4 +18,4 @@ public class Example7 {
    Example7.log(String@@@Object[]...)
  */
 
-/*!!!!! Example7.main2(String[]), 1,  287, 16 */
+/*!!!!! Example7.main2(String[]), 1,  285, 16 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/148-varargs-with-array-partial-match-Bug27/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/148-varargs-with-array-partial-match-Bug27/Test.java
@@ -18,4 +18,4 @@ public class Example7 {
    Example7.log(String@@@Object[]...)
  */
 
-/*!!!!! Example7.main2(String[]),  1, 287, 16 */
+/*!!!!! Example7.main2(String[]),  1, 285, 16 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/149-enum-variadic-Bug27/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/149-enum-variadic-Bug27/Test.java
@@ -21,4 +21,4 @@ public class Example8 {
    Priority.<staticinit>()
  */
 
-/*!!!!! Example8.main(String[]), 2, 315, 42, 266, 98 */
+/*!!!!! Example8.main(String[]), 2, 313, 42, 264, 98 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/150-cons-variadic-Bug27/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/150-cons-variadic-Bug27/Test.java
@@ -29,7 +29,7 @@ public class Example9 {
    Example9.<init>()
  */
 
-/*!!!!! Example9.main(String[]),  4, 315,31, 315, 38, 363,21,  363,14 */
+/*!!!!! Example9.main(String[]),  4, 313,31, 313,38, 361,21, 361,14 */
 
 // For the second empty constructor, we shall match with the default constructor here
 // instead of the Example9(String... items) constructor.

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/151-method-matching-Bug27/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/151-method-matching-Bug27/Test.java
@@ -20,4 +20,4 @@ public class Z {
    java.lang.Object#toString()
  */
 
-/*!!!!! Z#toString(),  2, 154,16, 176,20 */
+/*!!!!! Z#toString(),  2, 152,16, 174,20 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/152-param-match-Bug27/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/152-param-match-Bug27/Test.java
@@ -54,7 +54,7 @@ public class Z {
     }
 }
 
-/*!!!!! Z#foo(), 1, 1251, 34 */
+/*!!!!! Z#foo(), 1, 1249, 34 */
 
 /*$$$$$ Z#foo(), 
    1,
@@ -87,8 +87,8 @@ ComposedIterable#ComposedIterable(T@@@Iterable),
 ComposedIterable#ComposedIterable(Iterable@@@Iterable),
 */
 
-/*!!!!! Z#bar(), 1, 1358,34 */
-/*!!!!! Z#bazz(), 1, 1472,32 */
-/*!!!!! IterUtil.compose(Iterable@@@T), 1, 934,35 */
-/*!!!!! IterUtil.compose(T@@@Iterable), 1, 780,36 */
-/*!!!!! IterUtil.compose(Iterable@@@Iterable), 1,1103,31 */
+/*!!!!! Z#bar(), 1, 1356,34 */
+/*!!!!! Z#bazz(), 1, 1470,32 */
+/*!!!!! IterUtil.compose(Iterable@@@T), 1, 932,35 */
+/*!!!!! IterUtil.compose(T@@@Iterable), 1, 778,36 */
+/*!!!!! IterUtil.compose(Iterable@@@Iterable), 1,1101,31 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/153-variadic-no-param-partial-Bug27/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/153-variadic-no-param-partial-Bug27/Test.java
@@ -18,4 +18,4 @@ public class Example2 {
   1, Example2.printSum(Object@@@int[]...)
 */
 
-/*!!!!! Example2.main2(String[]),  1, 376,17 */
+/*!!!!! Example2.main2(String[]),  1, 374,17 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/154-variadic-no-param-partial-Bug27/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/154-variadic-no-param-partial-Bug27/Test.java
@@ -24,7 +24,7 @@ public class Example2 {
   1, Example2.printSum(String@@@int[]...)
 */
 
-/*!!!!! Example2.main2(String[]),  1, 558,17 */
+/*!!!!! Example2.main2(String[]),  1, 556,17 */
 
 // Compares between the two printSum methods,
 // then finds the best match to be with the printSum that matches best

--- a/bundles/org.openrefactory.callgraph/src/org/openrefactory/analysis/callgraph/CallGraphProcessor.java
+++ b/bundles/org.openrefactory.callgraph/src/org/openrefactory/analysis/callgraph/CallGraphProcessor.java
@@ -1815,8 +1815,12 @@ public class CallGraphProcessor implements Runnable {
                                         // Added extended call graph information as described above
                                         CallGraphDataStructures.getExtendedCallGraph().addEdge(callerMethodHash,
                                                 defaultConsOfAnonClass, invocationTokenRange);
+                                        // Issue 30
+                                        // Get the token range of the body of the anonymous class declaration
+                                        TokenRange anonymousDeclarationTokenRange = ASTNodeUtility
+                                            .getTokenRangeFromNode(anonClass, filePath);
                                         CallGraphDataStructures.getExtendedCallGraph().addEdge(defaultConsOfAnonClass,
-                                                superclassServicingConstructorHash, invocationTokenRange);
+                                            superclassServicingConstructorHash, anonymousDeclarationTokenRange);
                                         // Create information about the servicing method for this class instance
                                         // creation
                                         calleeContenders =
@@ -2258,6 +2262,10 @@ public class CallGraphProcessor implements Runnable {
                     }
                 }
                 if (allowedToLinkToSuperClassConstructors) {
+                    // Issue 30
+                    // The caller is the default constructor
+                    // The call site is the body of the class
+                    TokenRange range = CallGraphUtility.getTokeRangeFromClassHash(hashOfConstructorContainer);
                     if (superClassHash.startsWith(Constants.LIB_TYPE)) {
                         // Issue 25
                         // Added extended call graph information for a link
@@ -2270,7 +2278,6 @@ public class CallGraphProcessor implements Runnable {
                         superClassConstructorIdentity.setStaticBit();
                         superClassConstructorIdentity.setConstructorBit();
                         superClassConstructorIdentity.setDefaultBit();
-                        TokenRange range = CallGraphUtility.getTokeRangeFromMethodHash(constructorHash);
                         Pair<String, String> methodInfoPair = CallGraphUtility.getHashCodeAndSignatureOfLibraryMethod(
                             superClassConstructorIdentity, superClassHash, range);
                         if (methodInfoPair != null) {
@@ -2283,7 +2290,7 @@ public class CallGraphProcessor implements Runnable {
                         }
                     } else {
                         addCGEdgeToAppropriateSuperClassConstructor(
-                            superClassHash, constructorHash, anonymousInnerInstanceCreation, null);
+                            superClassHash, constructorHash, anonymousInnerInstanceCreation, range);
                     }
                 }
             }


### PR DESCRIPTION
Added /*!!!!! markers across callgraph tests to record exact call-site token offsets/lengths, and updated call graph processing to propagate token ranges for anonymous declarations, class-level constructors/initializers and super-constructor links.

Key changes:
- Added call-site token-range markers in ~60 test files (inner/anon/static/init/constructors/super/variadic cases)
- CallGraphProcessor now computes TokenRange for anonymous class bodies and class-level call sites and passes ranges when adding edges
- Small test coordinate adjustments and marker additions for multi-class/method scenarios