### PR TITLE
feat: Serialize call graph in capslock format (#32)

### DIFF
--- a/bundles/org.openrefactory.callgraph/META-INF/MANIFEST.MF
+++ b/bundles/org.openrefactory.callgraph/META-INF/MANIFEST.MF
@@ -16,4 +16,5 @@ Require-Bundle:
  org.eclipse.core.runtime;bundle-version="3.34.0",
  org.eclipse.core.resources;bundle-version="3.23.0",
  org.junit;bundle-version="4.13.2";resolution:=optional
+Export-Package: org.openrefactory.capslock
 Automatic-Module-Name: org.openrefactory.callgraph

--- a/bundles/org.openrefactory.callgraph/src/org/openrefactory/capslock/Call.java
+++ b/bundles/org.openrefactory.callgraph/src/org/openrefactory/capslock/Call.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2025-present OpenRefactory, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.openrefactory.capslock;
+
+import org.json.JSONObject;
+
+/**
+ * Issue 32
+ * 
+ * Represents a method invocation in capslock format.
+ * 
+ * @param caller   the index of the caller function
+ * @param callee   the index of the callee function
+ * @param callSite the call site of the method call
+ * 
+ * @author Rifat Rubayatul Islam
+ */
+public record Call(Long caller, Long callee, Site callSite) {
+
+    public JSONObject toJson() {
+        JSONObject call = new JSONObject();
+        call.put("caller", caller);
+        call.put("callee", callee);
+        call.put("callSite", callSite.toJson());
+        return call;
+    }
+}

--- a/bundles/org.openrefactory.callgraph/src/org/openrefactory/capslock/Function.java
+++ b/bundles/org.openrefactory.callgraph/src/org/openrefactory/capslock/Function.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025-present OpenRefactory, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.openrefactory.capslock;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.json.JSONObject;
+
+/**
+ * Issue 32
+ * 
+ * Represents a method in capslock format.
+ * 
+ * @param name              a human-readable fully-qualified name for the method
+ * @param packageIndex      the index of the package
+ * @param type              the container class/enum of the method
+ * @param function          the simple name of the method
+ * @param templateArguments the type arguments of the method call
+ * @param parameterTypes    the parameters of the method
+ * @param properties        the language specific special properties of a method
+ * @param language          the language of the function
+ * 
+ * @author Rifat Rubayatul Islam
+ */
+public record Function(String name, Long packageIndex, String type, String function, List<String> templateArguments,
+    List<String> parameterTypes, List<String> properties, String language) {
+
+    public Function(String name, Long packageIndex, String type, String function, List<String> parameterTypes,
+        String language) {
+        this(name, packageIndex, type, function, Collections.emptyList(), parameterTypes, Collections.emptyList(),
+            language);
+    }
+
+    public Function(String name, Long packageIndex, String type, String function, List<String> parameterTypes) {
+        this(name, packageIndex, type, function, parameterTypes, "java");
+    }
+
+    public Function(String name, Long packageIndex, String type, String function, List<String> parameterTypes,
+        List<String> properties) {
+        this(name, packageIndex, type, function, Collections.emptyList(), parameterTypes, properties, "java");
+    }
+
+    public JSONObject toJson() {
+        JSONObject func = new JSONObject();
+        func.put("name", name).put("function", function).put("packageIndex", packageIndex).put("type", type)
+            .put("templateArguments", templateArguments).put("parameterTypes", parameterTypes)
+            .put("properties", properties).put("language", language);
+        return func;
+    }
+}

--- a/bundles/org.openrefactory.callgraph/src/org/openrefactory/capslock/Graph.java
+++ b/bundles/org.openrefactory.callgraph/src/org/openrefactory/capslock/Graph.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2025-present OpenRefactory, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.openrefactory.capslock;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.Name;
+import org.json.JSONObject;
+import org.openrefactory.analysis.callgraph.CallGraphDataStructures;
+import org.openrefactory.analysis.callgraph.method.MethodIdentity;
+import org.openrefactory.analysis.type.typeinfo.TypeInfo;
+import org.openrefactory.util.CallGraphUtility;
+import org.openrefactory.util.datastructure.Pair;
+
+/**
+ * Issue 32
+ * 
+ * Contains necessary information of a call graph in the capslock format.
+ * 
+ * @author Rifat Rubayatul Islam
+ */
+public class Graph {
+    private String language;
+
+    private List<Function> functions;
+
+    private List<Call> calls;
+
+    private List<Package> packages;
+
+    private List<Module> modules;
+
+    // These maps are only for lookup. No need to serialize them
+    private Map<Function, Integer> functionIndexMap;
+
+    private Map<Package, Integer> packageIndexMap;
+
+    private Map<Module, Integer> moduleIndexMap;
+
+    public Graph() {
+        this.language = "java";
+        this.functions = new ArrayList<>();
+        this.functionIndexMap = new HashMap<>();
+        this.calls = new ArrayList<>();
+        this.packages = new ArrayList<>();
+        this.packageIndexMap = new HashMap<>();
+        this.modules = new ArrayList<>();
+        this.moduleIndexMap = new HashMap<>();
+    }
+
+    public int addFunction(Function func) {
+        if (functionIndexMap.containsKey(func)) { return functionIndexMap.get(func); }
+
+        int idx = functions.size();
+        functions.add(func);
+        functionIndexMap.put(func, idx);
+        return idx;
+    }
+
+    public int getFunctionIndex(Function func) {
+        return functionIndexMap.getOrDefault(func, -1);
+    }
+
+    public void addCall(Call call) {
+        calls.add(call);
+    }
+
+    public int addPackage(Package pkg) {
+        if (packageIndexMap.containsKey(pkg)) { return packageIndexMap.get(pkg); }
+
+        int idx = packages.size();
+        packages.add(pkg);
+        packageIndexMap.put(pkg, idx);
+        return idx;
+    }
+
+    public int getPackageIndex(Package pkg) {
+        return packageIndexMap.getOrDefault(pkg, -1);
+    }
+
+    public int addModule(Module mod) {
+        if (moduleIndexMap.containsKey(mod)) { return moduleIndexMap.get(mod); }
+
+        int idx = modules.size();
+        modules.add(mod);
+        moduleIndexMap.put(mod, idx);
+        return idx;
+    }
+
+    /**
+     *
+     * Helper method to populated function, package and module info.
+     *
+     * @param funcHash the hash of the function
+     * @return the index of the function if successful, -1 otherwise.
+     */
+    public int populateInfo(String funcHash) {
+        String callerClassHash = CallGraphUtility.getClassHashFromMethodHash(funcHash);
+        if (callerClassHash == null) return -1;
+
+        Pair<Name, Name> pkgAndMod = CallGraphUtility.getPackageAndModuleName(callerClassHash);
+        int modIdx = -1;
+        if (pkgAndMod.snd != null) {
+            modIdx = addModule(new Module(pkgAndMod.snd.getFullyQualifiedName(), "", ""));
+        }
+
+        int pkgIdx = -1;
+        String pkgName = "";
+        if (pkgAndMod.fst != null) {
+            pkgName = pkgAndMod.fst.getFullyQualifiedName();
+            pkgIdx = addPackage(
+                new Package(pkgName.substring(pkgName.lastIndexOf(".") + 1), pkgName, (long)modIdx, false, false));
+        }
+
+        int methodHashIndex = CallGraphDataStructures.getMethodIndexFromHash(funcHash);
+        if (methodHashIndex == -1) return -1;
+
+        MethodIdentity callerId = CallGraphDataStructures.getHashToMethodInfoBundleList().get(methodHashIndex)
+            .getIdentity();
+        List<String> paramTypes = callerId.getArgParamTypeInfos().stream().map(TypeInfo::toString)
+            .collect(Collectors.toList());
+
+        String funcCanonName = CallGraphUtility.getMethodNameInCanonicalizedFormat(funcHash, true);
+        // Parse the canonical name of the function and find the class name
+        Pattern classPattern = Pattern
+            .compile("(?<class>.+)[.#]((?<special>\\<.+\\>)|" + callerId.getMethodName() + ")\\(");
+        Matcher m = classPattern.matcher(funcCanonName);
+        String functionName = callerId.getMethodName();
+        List<String> properties = new ArrayList<>();
+        String className = "";
+        if (m.find()) {
+            className = m.group("class");
+            if (!pkgName.isBlank()) {
+                className = className.substring(pkgName.length() + 1);
+            }
+            
+            String special = m.group("special");
+            if (special != null) {
+                // Add properties for <init> and <staticinit>
+                functionName = special;
+                if (special.equals("<init>")) {
+                    properties.add("default constructor");
+                } else if (special.equals("<staticinit>")) {
+                    properties.add("static initializer");
+                }
+            }
+        }
+
+        return addFunction(new Function(funcCanonName, (long)pkgIdx, className, functionName, paramTypes, properties));
+    }
+
+    public JSONObject toJson() {
+        JSONObject graph = new JSONObject();
+        graph.put("language", language);
+        graph.put("functions", functions.stream().map(Function::toJson).collect(Collectors.toList()));
+        graph.put("calls", calls.stream().map(Call::toJson).collect(Collectors.toList()));
+        graph.put("packages", packages.stream().map(Package::toJson).collect(Collectors.toList()));
+        graph.put("modules", modules.stream().map(Module::toJson).collect(Collectors.toList()));
+        return graph;
+    }
+}

--- a/bundles/org.openrefactory.callgraph/src/org/openrefactory/capslock/Module.java
+++ b/bundles/org.openrefactory.callgraph/src/org/openrefactory/capslock/Module.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2025-present OpenRefactory, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.openrefactory.capslock;
+
+import org.json.JSONObject;
+
+/**
+ * Issue 32
+ * 
+ * Represents a module in capslock format.
+ * 
+ * @param name    the name of the module
+ * @param version the version of the module
+ * @param hash    the hash of the module
+ * 
+ * @author Rifat Rubayatul Islam
+ */
+public record Module(String name, String version, String hash) {
+    
+    public JSONObject toJson() {
+        JSONObject module = new JSONObject();
+        module.put("name", name);
+        module.put("version", version);
+        module.put("hash", hash);
+        return module;
+    }
+}

--- a/bundles/org.openrefactory.callgraph/src/org/openrefactory/capslock/Package.java
+++ b/bundles/org.openrefactory.callgraph/src/org/openrefactory/capslock/Package.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2025-present OpenRefactory, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.openrefactory.capslock;
+
+import org.json.JSONObject;
+
+/**
+ * Issue 32
+ * 
+ * Represents a package in capslock format.
+ * 
+ * @param name              the simple name of the package
+ * @param path              the qualified path of the package 
+ * @param module            the index of the container module
+ * @param isRoot            whether this is a root package
+ * @param isStandardLibrary whether this package is in the standard library
+ * 
+ * @author Rifat Rubayatul Islam
+ */
+public record Package(String name, String path, Long module, Boolean isRoot, Boolean isStandardLibrary) {
+    
+    public JSONObject toJson() {
+        JSONObject pkg = new JSONObject();
+        pkg.put("name", name);
+        pkg.put("path", path);
+        pkg.put("module", module);
+        pkg.put("isRoot", isRoot);
+        pkg.put("isStandardLibrary", isStandardLibrary);
+        return pkg;
+    }
+}

--- a/bundles/org.openrefactory.callgraph/src/org/openrefactory/capslock/Site.java
+++ b/bundles/org.openrefactory.callgraph/src/org/openrefactory/capslock/Site.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2025-present OpenRefactory, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.openrefactory.capslock;
+
+import org.json.JSONObject;
+
+/**
+ * Issue 32
+ * 
+ * Represents a call site in capslock format.
+ * 
+ * @param directory         the directory of the file that contains the call site
+ * @param filename          the name of the file that contains the call site
+ * @param line              the line of the method call
+ * @param column            the column of the method call
+ * 
+ * @author Rifat Rubayatul Islam
+ */
+public record Site(String directory, String filename, Long line, Long column) {
+
+    public JSONObject toJson() {
+        JSONObject callSite = new JSONObject();
+        callSite.put("directory", directory);
+        callSite.put("filename", filename);
+        callSite.put("line", line);
+        callSite.put("column", column);
+        return callSite;
+    }
+}

--- a/bundles/org.openrefactory.callgraph/src/org/openrefactory/cli/CallGraphPassCommand.java
+++ b/bundles/org.openrefactory.callgraph/src/org/openrefactory/cli/CallGraphPassCommand.java
@@ -14,8 +14,6 @@ import java.nio.file.Paths;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -26,10 +24,15 @@ import org.json.JSONObject;
 import org.openrefactory.analysis.callgraph.CallGraphDataStructures;
 import org.openrefactory.analysis.callgraph.MultiThreadCallGraphProcessor;
 import org.openrefactory.analysis.vpg.JavaVPG;
+import org.openrefactory.capslock.Call;
+import org.openrefactory.capslock.Graph;
+import org.openrefactory.capslock.Site;
 import org.openrefactory.model.IModel;
 import org.openrefactory.model.IModelFileElement;
 import org.openrefactory.model.Model;
+import org.openrefactory.util.ASTNodeUtility;
 import org.openrefactory.util.CallGraphUtility;
+import org.openrefactory.util.datastructure.IntPair;
 import org.openrefactory.util.datastructure.TokenRange;
 import org.openrefactory.util.manager.C2PManager;
 import org.openrefactory.util.manager.C2SManager;
@@ -210,22 +213,31 @@ public class CallGraphPassCommand {
 			String cgFileName = timeStamp + "_cg.json";
 			File cgFile = Path.of(ConfigurationManager.config.RESULT, cgFileName).toFile();
 			try (FileWriter fOut = new FileWriter(cgFile); BufferedWriter bw = new BufferedWriter(fOut)) {
-				Map<String, Set<String>> canonicalCallerToCalleeMap = new HashMap<String, Set<String>>();
 				Map<String, Map<TokenRange, Set<String>>> storedCallerToCalleeMap = CallGraphDataStructures
-						.getExtendedCallGraph().getCallerToCalleeMap();
-				for (Entry<String, Map<TokenRange, Set<String>>> callerEntry : storedCallerToCalleeMap.entrySet()) {
-					String callerName = CallGraphUtility.getMethodNameInCanonicalizedFormat(callerEntry.getKey(), true);
-					Map<TokenRange, Set<String>> rangeToCalleesMap = callerEntry.getValue();
-					Set<String> callees = new HashSet<String>(4);
-					for (java.util.Map.Entry<TokenRange, Set<String>> rangeToCallees : rangeToCalleesMap.entrySet()) {
+					.getExtendedCallGraph().getCallerToCalleeMap();
+				Graph cg = new Graph();
+				for (Entry<String, Map<TokenRange, Set<String>>> callerHashEntries : storedCallerToCalleeMap
+					.entrySet()) {
+					int callerIdx = cg.populateInfo(callerHashEntries.getKey());
+					for (Entry<TokenRange, Set<String>> rangeToCallees : callerHashEntries.getValue().entrySet()) {
+						TokenRange callTr = rangeToCallees.getKey();
+						// Extract line, column, file information from the token range
+						IntPair lineColumn = ASTNodeUtility.getLineAndColumn(callTr);
+						Path p = Path.of(callTr.getFileName());
+						// Calculate the relative directory path from the project root
+						Path projectRoot = Path.of(ConfigurationManager.config.SOURCE);
+						String fileName = p.getFileName().toString();
+						String parentDir = projectRoot.relativize(p.getParent()).toString();
+
 						for (String calleeHash : rangeToCallees.getValue()) {
-							String calleeName = CallGraphUtility.getMethodNameInCanonicalizedFormat(calleeHash, true);
-							callees.add(calleeName);
+							int calleeIdx = cg.populateInfo(calleeHash);
+							Site site = new Site(parentDir, fileName, (long)lineColumn.fst, (long)lineColumn.snd);
+							Call call = new Call((long)callerIdx, (long)calleeIdx, site);
+							cg.addCall(call);
 						}
 					}
-					canonicalCallerToCalleeMap.put(callerName, callees);
 				}
-				bw.write(new JSONObject(canonicalCallerToCalleeMap).toString(4));
+				bw.write(cg.toJson().toString(4));
 			} catch (Exception | Error e) {
 				progressReporter.showProgress("Failed to generate cg file: " + e.getMessage());
 			}

--- a/bundles/org.openrefactory.callgraph/src/org/openrefactory/util/CallGraphUtility.java
+++ b/bundles/org.openrefactory.callgraph/src/org/openrefactory/util/CallGraphUtility.java
@@ -35,6 +35,7 @@ import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.core.dom.Name;
 import org.eclipse.jdt.core.dom.SuperMethodInvocation;
 import org.eclipse.jdt.core.dom.Type;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
@@ -2167,4 +2168,25 @@ public class CallGraphUtility {
         }
     }
 
+    /**
+     * Issue 32
+     *
+     * Get the package and module name in which a class is in.
+     *
+     * @param classHash the class for which the package and module name is calculated
+     * @return A pair containing the package name and module name if available. Package name and
+     *         module name will be null if not found.
+     */
+    public static Pair<Name, Name> getPackageAndModuleName(String classHash) {
+        String sign = CallGraphDataStructures.getClassSignatureFromHash(classHash);
+        if (sign == null) return Pair.of(null, null);
+        ASTNode classNode = CallGraphUtility.getClassFromClassSignature(sign);
+        if (classNode == null) { return Pair.of(null, null); }
+        CompilationUnit comp = ASTNodeUtility.findNearestAncestor(classNode, CompilationUnit.class);
+        if (comp == null) { return Pair.of(null, null); }
+
+        Name packageName = comp.getPackage() == null ? null : comp.getPackage().getName();
+        Name moduleName = comp.getModule() == null ? null : comp.getModule().getName();
+        return Pair.of(packageName, moduleName);
+    }
 }


### PR DESCRIPTION
Introduced capslock package for standardized call graph serialization. Capslock provides Java record types for Graph, Function, Call, Site, Package, and Module with JSON export support.

Key changes:
- Added `org.openrefactory.capslock` package with records: Call, Function, Graph, Module, Package, Site
- Graph class manages function/call/package/module collections and indices
- Capslock records support JSON serialization via `toJson()` methods
- Extended `CallGraphPassCommand` and `CallGraphUtility` to support capslock output
- Exported capslock package in MANIFEST.MF for external use