### PR TITLE
feat: Add support for library method edges for string receivers (#54)

### DIFF
--- a/bundles/org.openrefactory.callgraph/callgraph-tests/132-default-cons-field-init-super-Bug25/Z.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/132-default-cons-field-init-super-Bug25/Z.java
@@ -33,8 +33,9 @@ public class Example1 {
 // Linking default constructor to library method calls for field initialization.
 
 /*$$$$$
-  Example1.<init>(), 1,
+  Example1.<init>(), 2,
   java.time.LocalDate.now(),
+  java.lang.String#hashCode()
 */
 
 /*!!!!! Example1#show(), 0 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/175-lib-method-edges-for-string-receivers-Bug54/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/175-lib-method-edges-for-string-receivers-Bug54/Test.java
@@ -1,0 +1,24 @@
+// Issue 54
+// Test for library instance method edges for String receivers
+
+class Name {
+    public static void printUpper() {
+        String upper = "hello".toUpperCase();
+    }
+}
+
+public class Demo {
+    public static void foo() {
+        Name.printUpper();
+    }
+}
+
+/*$$$$$ Demo.foo(),
+  1,
+  Name.printUpper()
+*/
+
+/*$$$$$ Name.printUpper(),
+  1,
+  java.lang.String#toUpperCase()
+*/

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/176-lib-method-edges-for-string-receivers-Bug54/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/176-lib-method-edges-for-string-receivers-Bug54/Test.java
@@ -1,0 +1,24 @@
+// Issue 54
+// Test for library instance method edges for String receivers
+
+class Name {
+    public static void printUpperConcat() {
+        String upper = ("he" + "llo").toUpperCase();
+    }
+}
+
+public class Demo {
+    public static void fooConcat() {
+        Name.printUpperConcat();
+    }
+}
+
+/*$$$$$ Demo.fooConcat(),
+  1,
+  Name.printUpperConcat()
+*/
+
+/*$$$$$ Name.printUpperConcat(),
+  1,
+  java.lang.String#toUpperCase()
+*/

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/177-lib-method-edges-for-string-receivers-Bug54/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/177-lib-method-edges-for-string-receivers-Bug54/Test.java
@@ -1,0 +1,24 @@
+// Issue 54
+// Test for library instance method edges for String receivers
+
+class Name {
+    public static void printUpperProperty() {
+        String upper = System.getProperty("user.home");
+    }
+}
+
+public class Demo {
+    public static void fooProperty() {
+        Name.printUpperProperty();
+    }
+}
+
+/*$$$$$ Demo.fooProperty(),
+  1,
+  Name.printUpperProperty()
+*/
+
+/*$$$$$ Name.printUpperProperty(),
+  1,
+  java.lang.System.getProperty(String)
+*/

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/178-lib-method-edges-for-string-receivers-Bug54/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/178-lib-method-edges-for-string-receivers-Bug54/Test.java
@@ -1,0 +1,25 @@
+// Issue 54
+// Test for library instance method edges for String receivers
+
+class Name {
+    public static void printUpperVar() {
+        String s = "hello";
+        String upper = s.toUpperCase();
+    }
+}
+
+public class Demo {
+    public static void fooVar() {
+        Name.printUpperVar();
+    }
+}
+
+/*$$$$$ Demo.fooVar(),
+  1,
+  Name.printUpperVar()
+*/
+
+/*$$$$$ Name.printUpperVar(),
+  1,
+  java.lang.String#toUpperCase()
+*/

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/179-lib-method-edges-for-string-receivers-Bug54/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/179-lib-method-edges-for-string-receivers-Bug54/Test.java
@@ -1,0 +1,13 @@
+// Issue 54
+// Test for library instance method edges for String.substring on literal receiver
+
+public class Name {
+    public static void printSubstringLiteral() {
+        String sub = "hello".substring(1);
+    }
+}
+
+/*$$$$$ Name.printSubstringLiteral(),
+  1,
+  java.lang.String#substring(int)
+*/

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/180-lib-method-edges-for-string-receivers-Bug54/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/180-lib-method-edges-for-string-receivers-Bug54/Test.java
@@ -1,0 +1,14 @@
+// Issue 54
+// Test for library instance method edges for String.indexOf on variable receiver
+
+public class Name {
+    public static void printIndexOfVar() {
+        String s = "hello";
+        int pos = s.indexOf("e");
+    }
+}
+
+/*$$$$$ Name.printIndexOfVar(),
+  1,
+  java.lang.String#indexOf(String)
+*/

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/181-lib-method-edges-for-string-receivers-Bug54/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/181-lib-method-edges-for-string-receivers-Bug54/Test.java
@@ -1,0 +1,25 @@
+// Issue 54
+// Simple test for a custom varargs function
+
+class Util {
+    static String bar(String delimiter, String... parts) {
+        return String.join(delimiter, parts);
+    }
+}
+
+public class Demo {
+    public static void foo() {
+        String result = Util.bar("-", "alpha", "beta", "gamma");
+        System.out.println(result);
+    }
+}
+
+/*$$$$$ Demo.foo(),
+  1,
+  Util.bar(String@@@String[]...)
+*/
+
+/*$$$$$ Util.bar(String@@@String[]...),
+  1,
+  java.lang.String.join(String@@@String[])
+*/

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/182-lib-method-edges-for-string-receivers-Bug54/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/182-lib-method-edges-for-string-receivers-Bug54/Test.java
@@ -1,0 +1,16 @@
+// Issue 54
+// Test for library instance method edges for String.isEmpty inside a conditional
+
+public class Name {
+    public static void checkEmpty() {
+        String s = "";
+        if (s.isEmpty()) {
+            // no operation
+        }
+    }
+}
+
+/*$$$$$ Name.checkEmpty(),
+  1,
+  java.lang.String#isEmpty()
+*/

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/183-lib-method-edges-for-string-receivers-Bug54/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/183-lib-method-edges-for-string-receivers-Bug54/Test.java
@@ -1,0 +1,32 @@
+// Issue 54
+// Test for library instance method edges in an inheritance hierarchy
+
+class ParentName {
+    protected String provideName() {
+        return "ParentUser";
+    }
+}
+
+class ChildName extends ParentName {
+    public void formatInherited() {
+        String lower = provideName().toLowerCase();
+    }
+}
+
+public class Demo {
+    public static void fooInherited() {
+        new ChildName().formatInherited();
+    }
+}
+
+/*$$$$$ Demo.fooInherited(),
+  2,
+  ChildName.<init>(),
+  ChildName#formatInherited()
+*/
+
+/*$$$$$ ChildName#formatInherited(),
+  2,
+  ParentName#provideName(),
+  java.lang.String#toLowerCase()
+*/

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/184-lib-method-edges-for-string-receivers-Bug54/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/184-lib-method-edges-for-string-receivers-Bug54/Test.java
@@ -1,0 +1,27 @@
+// Issue 54
+// Test for library instance method edges inside a nested class
+
+class OuterName {
+    static class Inner {
+        void sanitize() {
+            String cleaned = ("hello" + " world").replace(" ", "-");
+        }
+    }
+}
+
+public class Demo {
+    public static void fooNested() {
+        new OuterName.Inner().sanitize();
+    }
+}
+
+/*$$$$$ Demo.fooNested(),
+  2,
+  OuterName.Inner.<init>(),
+  OuterName.Inner#sanitize()
+*/
+
+/*$$$$$ OuterName.Inner#sanitize(),
+  1,
+  java.lang.String#replace(String@@@String)
+*/

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/185-lib-method-edges-for-string-receivers-Bug54/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/185-lib-method-edges-for-string-receivers-Bug54/Test.java
@@ -1,0 +1,24 @@
+// Issue 54
+// Test for library instance method edges in String.format
+
+class Name {
+    public static void formatVarArgs() {
+        String result = String.format("User-%s-%d", "Alice", 42);
+    }
+}
+
+public class Demo {
+    public static void fooFormatVarArgs() {
+        Name.formatVarArgs();
+    }
+}
+
+/*$$$$$ Demo.fooFormatVarArgs(),
+  1,
+  Name.formatVarArgs()
+*/
+
+/*$$$$$ Name.formatVarArgs(),
+  1,
+  java.lang.String.format(String@@@String@@@int)
+*/

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/186-lib-method-edges-for-string-receivers-Bug54/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/186-lib-method-edges-for-string-receivers-Bug54/Test.java
@@ -1,0 +1,32 @@
+// Issue 54
+// Inheritance scenario with String substring on a value from the superclass
+
+class BaseName {
+    protected String baseLabel() {
+        return "BASE-NAME";
+    }
+}
+
+class ChildName extends BaseName {
+    public void process() {
+        String suffix = baseLabel().substring(5);
+    }
+}
+
+public class Demo {
+    public static void fooInheritanceComplex() {
+        new ChildName().process();
+    }
+}
+
+/*$$$$$ Demo.fooInheritanceComplex(),
+  2,
+  ChildName.<init>(),
+  ChildName#process()
+*/
+
+/*$$$$$ ChildName#process(),
+  2,
+  BaseName#baseLabel(),
+  java.lang.String#substring(int)
+*/

--- a/bundles/org.openrefactory.callgraph/src/org/openrefactory/util/CallGraphUtility.java
+++ b/bundles/org.openrefactory.callgraph/src/org/openrefactory/util/CallGraphUtility.java
@@ -29,6 +29,7 @@ import org.eclipse.jdt.core.dom.AnonymousClassDeclaration;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.EnumDeclaration;
+import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
@@ -1464,14 +1465,28 @@ public class CallGraphUtility {
             MethodInvocation invocation,
             String callerMethodHash,
             NeoLRUCache<String, Pair<TypeInfo, TokenRange>> methodCallingContextCache) {
-        ASTNode callingContextExpressionOfInvocation = invocation.getExpression();
+        Expression callingContextExpressionOfInvocation = invocation.getExpression();
         String callingContextDeclaredTypeHash = null;
         if (callingContextExpressionOfInvocation != null) {
-            TypeInfo callingContextDeclaredtype = TypeCalculator.getCallingContextType(
-                    callingContextExpressionOfInvocation, methodCallingContextCache);
-            // Skip if the calling context type is Array
-            if (callingContextDeclaredtype != null && !(callingContextDeclaredtype instanceof ArrayTypeInfo)) {
-                callingContextDeclaredTypeHash = callingContextDeclaredtype.getName();
+            // Issue 54
+            // First try to use the type binding of the calling-context expression so that
+            // both source & library types map to the correct class hash or library type hash.
+            ITypeBinding typeBinding = callingContextExpressionOfInvocation.resolveTypeBinding();
+            if (typeBinding != null) {
+                CompilationUnit cu = ASTNodeUtility.findNearestAncestor(invocation, CompilationUnit.class);
+                String filePath = ASTNodeUtility.getFilePathFromCompilationUnit(cu);
+                callingContextDeclaredTypeHash = CallGraphUtility.getClassHashFromTypeBinding(
+                        typeBinding, null, filePath);
+            }
+            if (callingContextDeclaredTypeHash == null) {
+                // Fallback to the previous behavior based on TypeInfo
+                // when binding is unavailable
+                TypeInfo callingContextDeclaredtype = TypeCalculator.getCallingContextType(
+                        callingContextExpressionOfInvocation, methodCallingContextCache);
+                // Skip if the calling context type is Array
+                if (callingContextDeclaredtype != null && !(callingContextDeclaredtype instanceof ArrayTypeInfo)) {
+                    callingContextDeclaredTypeHash = callingContextDeclaredtype.getName();
+                }
             }
         } else {
             // No calling context expression, so calling context type is this


### PR DESCRIPTION

### My approach for solving the issue:
- `CallGraphUtility.getCallingContextDeclaredTypeHashOfMethodInvocation` now resolves the receiver’s `ITypeBinding` before falling back to the existing `TypeCalculator`-based logic, ensuring literal and library-provided `String` values are mapped to the correct LIB hashes so `ExtendedCallGraphUtils` can connect them to their library methods. 

