### PR TITLE
fix: Param types inconsistent with the method signature in the json (#60)

### DIFF
--- a/bundles/org.openrefactory.callgraph/callgraph-tests/101-static-nested-cons-Bug23/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/101-static-nested-cons-Bug23/Test.java
@@ -28,10 +28,10 @@ public class AnotherClass {
 }
 
 /*$$$$$ Example6Custom#demo(), 1,
- 		17,39, 1, Example6Custom.Pair#Pair(K@@@V)
+ 		17,39, 1, Example6Custom.Pair#Pair(Object@@@Object)
 */
 
 
 /*$$$$$ AnotherClass.main(String[]), 1,
-		24,54, 1, Example6Custom.Pair#Pair(K@@@V)
+		24,54, 1, Example6Custom.Pair#Pair(Object@@@Object)
 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/108-static-nested-cons-Bug25/Z.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/108-static-nested-cons-Bug25/Z.java
@@ -28,10 +28,10 @@ public class AnotherClass {
 }
 
 /*$$$$$ Example6Custom#demo(), 1,
-		17,39, 1, Example6Custom.Pair#Pair(K@@@V)
+		17,39, 1, Example6Custom.Pair#Pair(Object@@@Object)
 */
 
 
 /*$$$$$ AnotherClass.main(String[]), 1,
-		24,54, 1, Example6Custom.Pair#Pair(K@@@V)
+		24,54, 1, Example6Custom.Pair#Pair(Object@@@Object)
 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/123-super-method-Bug25/Z.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/123-super-method-Bug25/Z.java
@@ -19,6 +19,6 @@ public class MyList<E> extends ArrayList<E> {
   		14,31, 1, MyList.<init>(),
 */
 
-/*$$$$$ MyList#add(E), 1,
-  		10,16, 1, java.util.ArrayList#add(E)
+/*$$$$$ MyList#add(Object), 1,
+  		10,16, 1, java.util.ArrayList#add(Object)
 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/143-varargs-symbolic-array-Bug27/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/143-varargs-symbolic-array-Bug27/Test.java
@@ -15,5 +15,5 @@ public class Example4 {
 }
 
 /*$$$$$ Example4.main(String[]), 1,
-		13,9, 1, Example4.printAll(T[]...)
+		13,9, 1, Example4.printAll(Object[]...)
 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/144-variadic-symbolic-Bug27/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/144-variadic-symbolic-Bug27/Test.java
@@ -16,6 +16,6 @@ public class Example5 {
 }
 
 /*$$$$$ Example5.main(String[]), 2,
-		13,9, 1, Example5.printAll(T[]...),
-		14,9, 1, Example5.printAll(T[]...)
+		13,9, 1, Example5.printAll(Object[]...),
+		14,9, 1, Example5.printAll(Object[]...)
 */

--- a/bundles/org.openrefactory.callgraph/callgraph-tests/152-param-match-Bug27/Test.java
+++ b/bundles/org.openrefactory.callgraph/callgraph-tests/152-param-match-Bug27/Test.java
@@ -55,23 +55,23 @@ public class Z {
 }
 
 /*$$$$$ Z#foo(), 1,
-		42,18, 1, IterUtil.compose(Iterable@@@T),
+		42,18, 1, IterUtil.compose(Iterable@@@Object),
 */
 
 /*$$$$$ Z#bar(), 1,
-		47,18, 1, IterUtil.compose(T@@@Iterable),
+		47,18, 1, IterUtil.compose(Object@@@Iterable),
 */
 
 /*$$$$$ Z#bazz(), 1,
 		53,18, 1, IterUtil.compose(Iterable@@@Iterable),
 */
 
-/*$$$$$ IterUtil.compose(Iterable@@@T), 1,
-		30,16, 1, ComposedIterable#ComposedIterable(Iterable@@@T),
+/*$$$$$ IterUtil.compose(Iterable@@@Object), 1,
+		30,16, 1, ComposedIterable#ComposedIterable(Iterable@@@Object),
 */
 
-/*$$$$$ IterUtil.compose(T@@@Iterable), 1,
-		26,16, 1, ComposedIterable#ComposedIterable(T@@@Iterable),
+/*$$$$$ IterUtil.compose(Object@@@Iterable), 1,
+		26,16, 1, ComposedIterable#ComposedIterable(Object@@@Iterable),
 */
 
 /*$$$$$ IterUtil.compose(Iterable@@@Iterable), 1,

--- a/bundles/org.openrefactory.callgraph/src/org/openrefactory/analysis/callgraph/ExtendedCallGraph.java
+++ b/bundles/org.openrefactory.callgraph/src/org/openrefactory/analysis/callgraph/ExtendedCallGraph.java
@@ -198,7 +198,7 @@ public class ExtendedCallGraph {
 
 		MethodIdentity funcId = CallGraphDataStructures.getHashToMethodInfoBundleList().get(methodHashIndex)
 				.getIdentity();
-		List<String> paramTypes = funcId.getArgParamTypeInfos().stream().map(TypeInfo::toString).collect(toList());
+		List<String> paramTypes = funcId.getArgParamTypeInfos().stream().map(TypeInfo::getErasuredSimpleName).collect(toList());
 
 		String funcCanonName = CallGraphUtility.getMethodNameInCanonicalizedFormat(funcHash, true);
 		// Parse the canonical name of the function and find the class name

--- a/bundles/org.openrefactory.callgraph/src/org/openrefactory/analysis/type/typeinfo/ArrayTypeInfo.java
+++ b/bundles/org.openrefactory.callgraph/src/org/openrefactory/analysis/type/typeinfo/ArrayTypeInfo.java
@@ -122,6 +122,22 @@ public final class ArrayTypeInfo extends TypeInfo {
         // So, getting erasure for just the element type does not create problems.
         return elementType.getTypeErasure();
     }
+    
+    /**
+     * @return the SimpleName of the element after type erasure followed by [] (and ... for var-args)
+     */
+    @Override
+    public String getErasuredSimpleName() {
+        StringBuilder builder = new StringBuilder();
+        builder.append(elementType.getErasuredSimpleName());
+        for (int i = 0; i < dimension; i++) {
+            builder.append("[]");
+        }
+        if (isVarArgs) {
+            builder.append("...");
+        }
+        return builder.toString();
+    }
 
     @Override
     public Map<String, Pair<Pair<TokenRange, Integer>, TypeInfo>> getFields() {

--- a/bundles/org.openrefactory.callgraph/src/org/openrefactory/analysis/type/typeinfo/ClassTypeInfo.java
+++ b/bundles/org.openrefactory.callgraph/src/org/openrefactory/analysis/type/typeinfo/ClassTypeInfo.java
@@ -136,6 +136,19 @@ public final class ClassTypeInfo extends TypeInfo {
     public String getTypeErasure() {
         return this.name;
     }
+    
+    /**
+     * @return the simple name of the class. For anonymous inner class it returns
+     * the simple name of the interface/abstract class.
+     */
+    @Override
+    public String getErasuredSimpleName() {
+        String simpleName = this.toString();
+        // For anonymous inner class, the type name contains ANON__OR__TYPE$ prefix.
+        // This prefix is not necessary for method signature. So, we are taking only
+        // interface/abstract class name after the $ sign.
+        return simpleName.substring(simpleName.lastIndexOf("$") + 1);
+    }
 
     /**
      * Checks whether this class type matches the required declaration type.

--- a/bundles/org.openrefactory.callgraph/src/org/openrefactory/analysis/type/typeinfo/EnumTypeInfo.java
+++ b/bundles/org.openrefactory.callgraph/src/org/openrefactory/analysis/type/typeinfo/EnumTypeInfo.java
@@ -127,6 +127,11 @@ public final class EnumTypeInfo extends TypeInfo {
     public String getTypeErasure() {
         return this.name;
     }
+    
+    @Override
+    public String getErasuredSimpleName() {
+        return this.toString();
+    }
 
     /**
      * Checks whether this enum type matches the required declaration type.

--- a/bundles/org.openrefactory.callgraph/src/org/openrefactory/analysis/type/typeinfo/ParameterizedTypeInfo.java
+++ b/bundles/org.openrefactory.callgraph/src/org/openrefactory/analysis/type/typeinfo/ParameterizedTypeInfo.java
@@ -376,6 +376,21 @@ public final class ParameterizedTypeInfo extends TypeInfo {
     public String getTypeErasure() {
         return this.name;
     }
+    
+    /**
+     * @return the simple name of the parameterized type after erasure. For anonymous inner class it returns
+     * the simple name of the interface/abstract class after type erasure.
+     */
+    @Override
+    public String getErasuredSimpleName() {
+        String simpleName = CallGraphUtility.getClassNameFromClassHash(name);
+        // To keep it consistent with other types, we are taking last index of dot instead of the
+        // heuristic used in toString method.
+        // Also, for anonymous inner class, the type name contains ANON__OR__TYPE$ prefix.
+        // This prefix is not necessary for method signature. So, we are taking only
+        // interface/abstract class name after the $ sign.
+        return simpleName.substring(simpleName.lastIndexOf(".") + 1).substring(simpleName.lastIndexOf("$") + 1);
+    }
 
     /**
      * Checks whether this parameterized type matches the required declaration type.

--- a/bundles/org.openrefactory.callgraph/src/org/openrefactory/analysis/type/typeinfo/RecordTypeInfo.java
+++ b/bundles/org.openrefactory.callgraph/src/org/openrefactory/analysis/type/typeinfo/RecordTypeInfo.java
@@ -69,6 +69,11 @@ public final class RecordTypeInfo extends TypeInfo {
     public String getTypeErasure() {
         return this.name;
     }
+    
+    @Override
+    public String getErasuredSimpleName() {
+        return this.toString();
+    }
 
     @Override
     public boolean matches(TypeInfo declarationType) {

--- a/bundles/org.openrefactory.callgraph/src/org/openrefactory/analysis/type/typeinfo/ScalarTypeInfo.java
+++ b/bundles/org.openrefactory.callgraph/src/org/openrefactory/analysis/type/typeinfo/ScalarTypeInfo.java
@@ -353,6 +353,11 @@ public final class ScalarTypeInfo extends TypeInfo {
     public String getTypeErasure() {
         return this.name;
     }
+    
+    @Override
+    public String getErasuredSimpleName() {
+        return this.toString();
+    }
 
     @Override
     public Map<String, Pair<Pair<TokenRange, Integer>, TypeInfo>> getFields() {

--- a/bundles/org.openrefactory.callgraph/src/org/openrefactory/analysis/type/typeinfo/SymbolicTypeInfo.java
+++ b/bundles/org.openrefactory.callgraph/src/org/openrefactory/analysis/type/typeinfo/SymbolicTypeInfo.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.openrefactory.analysis.callgraph.CallGraphDataStructures;
+import org.openrefactory.util.CallGraphUtility;
 import org.openrefactory.util.Constants;
 import org.openrefactory.util.datastructure.ObjectIntPair;
 import org.openrefactory.util.datastructure.Pair;
@@ -171,6 +172,13 @@ public final class SymbolicTypeInfo extends TypeInfo {
             // Take the erasure of the first bound
             return boundTypes.get(0).getTypeErasure();
         }
+    }
+    
+    @Override
+    public String getErasuredSimpleName() {
+        String typeName = CallGraphUtility.getClassNameFromClassHash(this.getTypeErasure());
+        // Get the part after the last dot as the SimpleName of the type
+        return typeName.substring(typeName.lastIndexOf(".") + 1);
     }
 
     /**

--- a/bundles/org.openrefactory.callgraph/src/org/openrefactory/analysis/type/typeinfo/TypeInfo.java
+++ b/bundles/org.openrefactory.callgraph/src/org/openrefactory/analysis/type/typeinfo/TypeInfo.java
@@ -72,6 +72,14 @@ public abstract class TypeInfo implements Serializable {
      *         {@link Constants#JAVA_LANG_OBJECT} otherwise
      */
     public abstract String getTypeErasure();
+    
+    /**
+     * Issue 60
+     *
+     * @return the simple name of the type after type erasure.
+     * @see TypeInfo#getTypeErasure()
+     */
+    public abstract String getErasuredSimpleName();
 
     /**
      * Creates a deep copy of this TypeInfo object.

--- a/bundles/org.openrefactory.callgraph/src/org/openrefactory/analysis/type/typeinfo/WildCardTypeInfo.java
+++ b/bundles/org.openrefactory.callgraph/src/org/openrefactory/analysis/type/typeinfo/WildCardTypeInfo.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.openrefactory.analysis.callgraph.CallGraphDataStructures;
+import org.openrefactory.util.CallGraphUtility;
 import org.openrefactory.util.Constants;
 import org.openrefactory.util.datastructure.ObjectIntPair;
 import org.openrefactory.util.datastructure.Pair;
@@ -204,6 +205,13 @@ public final class WildCardTypeInfo extends TypeInfo {
             // Take the erasure of the bound
             return boundType.getTypeErasure();
         }
+    }
+    
+    @Override
+    public String getErasuredSimpleName() {
+        String typeName = CallGraphUtility.getClassNameFromClassHash(this.getTypeErasure());
+        // Get the part after the last dot as the SimpleName of the type
+        return typeName.substring(typeName.lastIndexOf(".") + 1);
     }
 
     /**

--- a/bundles/org.openrefactory.callgraph/src/org/openrefactory/util/CallGraphUtility.java
+++ b/bundles/org.openrefactory.callgraph/src/org/openrefactory/util/CallGraphUtility.java
@@ -2110,7 +2110,7 @@ public class CallGraphUtility {
         // Create method param types
         StringBuffer argBuf = new StringBuffer();
         for (TypeInfo typeInfo : identity.getArgParamTypeInfos()) {
-            argBuf.append(TypeCalculator.getTypeWithErasure(typeInfo));
+            argBuf.append(typeInfo.getErasuredSimpleName());
             argBuf.append(",");
         }
         if (identity.getArgParamTypeInfos().size() > 0) {


### PR DESCRIPTION
Updated method signature and parameter type calculation to be consistent with each other.

- Fixed parameter types in method signature.
- Incorporated type erasure in parameter type calculation.
- Updated existing test cases.

closes #60 